### PR TITLE
fix: should remove default alias for dayjs

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,14 +5,6 @@ const updateResource = (resource) => {
 const plugin = 'AntdMomentWebpackPlugin';
 class Plugin {
   apply(compiler) {
-    const { alias } = compiler.options.resolve;
-    if (alias) {
-      alias.dayjs = 'moment';
-    } else {
-      compiler.options.resolve.alias = {
-        dayjs: 'moment',
-      };
-    }
     compiler.hooks.normalModuleFactory.tap(plugin, (factory) => {
       factory.hooks.beforeResolve.tap(plugin, (result) => {
         if (generateRegExp.test(result.request)) {


### PR DESCRIPTION
- `dayjs` in project should not alias to `moment` by default. It should take effect for `antd` only.
- Fix #2.

![image](https://user-images.githubusercontent.com/14918822/206109579-e8cefea0-f662-486a-9730-515e598de426.png)

- `antd` doesn't use `dayjs` directly in source code.

![image](https://user-images.githubusercontent.com/14918822/206137174-7a7b6273-2d92-49f8-b505-c65c21cdb749.png)

- Only [rc-picker](https://github.com/react-component/picker) use `dayjs` directly. So replacing `generate/dayjs` import only is reasonable.

![image](https://user-images.githubusercontent.com/14918822/206137784-64f0f182-040e-4505-a0c7-15e831120e1c.png)