### PR TITLE
feat: Add disableDayjsAlias option

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,14 +4,20 @@ const updateResource = (resource) => {
 };
 const plugin = 'AntdMomentWebpackPlugin';
 class Plugin {
+  constructor (options) {
+    this.options = options || {};
+  }
   apply(compiler) {
+    const { disableDayjsAlias } = this.options;
     const { alias } = compiler.options.resolve;
-    if (alias) {
-      alias.dayjs = 'moment';
-    } else {
-      compiler.options.resolve.alias = {
-        dayjs: 'moment',
-      };
+    if (!disableDayjsAlias) {
+      if (alias) {
+        alias.dayjs = 'moment';
+      } else {
+        compiler.options.resolve.alias = {
+          dayjs: 'moment',
+        };
+      }
     }
     compiler.hooks.normalModuleFactory.tap(plugin, (factory) => {
       factory.hooks.beforeResolve.tap(plugin, (result) => {


### PR DESCRIPTION
- Add `disableDayjsAlias` option to allow `dayjs` not alias to `moment` outside antd.
- Another PR #3 needs more testing, so hold it for now.
- Fix #2.

![image](https://user-images.githubusercontent.com/14918822/206109579-e8cefea0-f662-486a-9730-515e598de426.png)