### PR TITLE
fix: compatible with webpack4

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A webpack plugin to replace [Day.js](https://day.js.org/) to [Moment.js](http://
 npm install --save-dev @ant-design/moment-webpack-plugin
 ```
 
-## Usage
+## Default Usage
 ```js
 // webpack-config.js
 import AntdMomentWebpackPlugin from '@ant-design/moment-webpack-plugin';
@@ -16,5 +16,19 @@ import AntdMomentWebpackPlugin from '@ant-design/moment-webpack-plugin';
 module.exports = {
   // ...
   plugins: [new AntdMomentWebpackPlugin()],
+};
+```
+
+## disableDayjsAlias
+`disableDayjsAlias` option to allow dayjs not alias to `moment` outside antd
+```js
+// webpack-config.js
+import AntdMomentWebpackPlugin from '@ant-design/moment-webpack-plugin';
+
+module.exports = {
+  // ...
+  plugins: [new AntdMomentWebpackPlugin({
+    disableDayjsAlias: true
+  })],
 };
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # antd-moment-webpack-plugin
 
-A webpack plugin to replace [Day.js](https://day.js.org/) to [Moment.js](http://momentjs.com/) automatically.
+A webpack plugin to replace [Day.js](https://day.js.org/) to [Moment.js](http://momentjs.com/) automatically. compatible with webpack4 and webpack 5.
 
 
 ## Installation

--- a/index.js
+++ b/index.js
@@ -1,7 +1,5 @@
 const generateRegExp = /generate\/dayjs/;
-const updateResource = (resource) => {
-  resource.request = resource.request.replace('dayjs', 'moment');
-};
+
 const plugin = 'AntdMomentWebpackPlugin';
 class Plugin {
   constructor(options) {
@@ -22,7 +20,7 @@ class Plugin {
     compiler.hooks.normalModuleFactory.tap(plugin, (factory) => {
       factory.hooks.beforeResolve.tap(plugin, (result) => {
         if (generateRegExp.test(result.request)) {
-          updateResource(result);
+          result.request = result.request.replace('dayjs', 'moment');
         }
       });
       factory.hooks.afterResolve.tap(plugin, (result) => {

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const updateResource = (resource) => {
 };
 const plugin = 'AntdMomentWebpackPlugin';
 class Plugin {
-  constructor (options) {
+  constructor(options) {
     this.options = options || {};
   }
   apply(compiler) {
@@ -26,9 +26,9 @@ class Plugin {
         }
       });
       factory.hooks.afterResolve.tap(plugin, (result) => {
-        const createData = result.createData;
-        if (generateRegExp.test(createData.resource)) {
-          updateResource(result);
+        const data = result.createData ? result.createData : result;
+        if (generateRegExp.test(data.resource)) {
+          data.resource = data.resource.replace('dayjs', 'moment')
         }
       });
     });


### PR DESCRIPTION
本地使用 webpack4 启动，加入判断进行兼容后，可以解决 createData 为 undefined 的错误，不过看起来第 afterResolve 中的判断在简单的  `DatePicker` 场景下并没有用到，
<img width="875" alt="image" src="https://user-images.githubusercontent.com/32009993/225687444-927305d6-39f2-4c9a-aff0-33b3b28108fb.png">
<img width="388" alt="image" src="https://user-images.githubusercontent.com/32009993/225687478-0202baa9-9936-41c9-b28e-82f511cdd495.png">

umi3 默认使用 webpack 4
<img width="801" alt="image" src="https://user-images.githubusercontent.com/32009993/225687512-abf3c0be-5e69-4aa2-89d4-ed1f542a79dd.png">
