### PR TITLE
fix: type incompatibility with Webpack plugins[]

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from "webpack";
+import type { Plugin, Compiler } from "webpack";
 
 declare namespace AntdMomentWebpackPlugin {
   interface Options {
@@ -9,6 +9,7 @@ declare class AntdMomentWebpackPlugin extends Plugin {
   constructor(
     options?: AntdMomentWebpackPlugin.Options
   );
+  apply(compiler: Compiler): void;
 }
 
 export = AntdMomentWebpackPlugin;


### PR DESCRIPTION
Follow up from #13 - a small mistake from my side, sorry!
With `@ant-design/moment-webpack-plugin@0.0.4` I received the following error within my `webpack.config.ts`

跟进 #13 - 我犯了一个小错误，抱歉！
在使用 `@ant-design/moment-webpack-plugin@0.0.4` 时，我的 `webpack.config.ts` 中出现了以下错误

![Screenshot 2023-09-07 at 13 40 39](https://github.com/ant-design/antd-moment-webpack-plugin/assets/9899423/12daf41c-aefb-4245-9e5f-485b801dd0c3)

With this PR:
有了这次公关：

![Screenshot 2023-09-07 at 13 41 39](https://github.com/ant-design/antd-moment-webpack-plugin/assets/9899423/22897a79-84f8-442f-8ca9-7a0511bb8f07)
